### PR TITLE
Wrong media type in content-type response headers

### DIFF
--- a/bruno/Get A Collection.bru
+++ b/bruno/Get A Collection.bru
@@ -26,7 +26,7 @@ tests {
 
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
 

--- a/bruno/Get API Root Information.bru
+++ b/bruno/Get API Root Information.bru
@@ -21,7 +21,7 @@ tests {
   
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
   

--- a/bruno/Get An Object.bru
+++ b/bruno/Get An Object.bru
@@ -28,7 +28,7 @@ tests {
   
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
   

--- a/bruno/Get Collections.bru
+++ b/bruno/Get Collections.bru
@@ -21,7 +21,7 @@ tests {
 
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
 

--- a/bruno/Get Object Manifests.bru
+++ b/bruno/Get Object Manifests.bru
@@ -25,7 +25,7 @@ tests {
 
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
 

--- a/bruno/Get Object Versions.bru
+++ b/bruno/Get Object Versions.bru
@@ -30,7 +30,7 @@ tests {
 
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
 

--- a/bruno/Get Objects.bru
+++ b/bruno/Get Objects.bru
@@ -37,7 +37,7 @@ tests {
 
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
 

--- a/bruno/Server Discovery.bru
+++ b/bruno/Server Discovery.bru
@@ -21,7 +21,7 @@ tests {
   
   test("Verify response content type", function() {
     const contentType = res.getHeader('content-type');
-    expect(contentType).to.include('application/stix+json');
+    expect(contentType).to.include('application/taxii+json');
     expect(contentType).to.include('version=2.1');
   });
   

--- a/src/common/interceptors/set-response-media-type.interceptor.ts
+++ b/src/common/interceptors/set-response-media-type.interceptor.ts
@@ -24,10 +24,10 @@ export class SetResponseMediaType implements NestInterceptor {
 
         const requestedMediaType: MediaTypeObject = req[MEDIA_TYPE_TOKEN];
 
-        requestedMediaType._subType = requestedMediaType._subType.replace(
-          "taxii",
-          "stix"
-        );
+        // requestedMediaType._subType = requestedMediaType._subType.replace(
+        //   "taxii",
+        //   "stix"
+        // );
 
         const contentType = requestedMediaType.toString();
 

--- a/src/common/interceptors/set-response-media-type.interceptor.ts
+++ b/src/common/interceptors/set-response-media-type.interceptor.ts
@@ -24,14 +24,7 @@ export class SetResponseMediaType implements NestInterceptor {
 
         const requestedMediaType: MediaTypeObject = req[MEDIA_TYPE_TOKEN];
 
-        // requestedMediaType._subType = requestedMediaType._subType.replace(
-        //   "taxii",
-        //   "stix"
-        // );
-
         const contentType = requestedMediaType.toString();
-
-        contentType.replace("taxii", "stix");
 
         res.setHeader("Content-Type", contentType);
       })


### PR DESCRIPTION
Closes #17 

Fixes an issue where the TAXII sets the wrong media type in the `Content-Type` response header